### PR TITLE
Приводим пути к unix-разделителю, чтобы хеши на разных ОС совпадали

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -120,7 +120,7 @@ const getName = ({ rootPath, componentNode }) =>
     : componentNode.id.name)
 
 const getId = (filename, name) =>
-  hash(`${path.relative(projectPath, filename)}:${name}`).toString(16)
+  hash(`${path.relative(projectPath, filename)}:${name}`.split(path.sep).join('/')).toString(16)
 
 module.exports = {
   getNode,


### PR DESCRIPTION
Сейчас хеши для модулей на unix-машинах и windows-машинах не совпадают из-за разных разделителей пути. Можно привести всё к '/'.