### PR TITLE
Typescript selector addon

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 // inlined to avoid depending on @types/react
-type ComponentType = (...args: any[]) => JSX.Element;
+type ComponentType = (...args: any[]) => any;
 
 type ResolvedValue = string;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,7 +3,7 @@ type ComponentType = (...args: any[]) => JSX.Element;
 
 type ResolvedValue = string;
 
-type Selector = (strings: TemplateStringsArray, ... values: (ResolvedValue | ComponentType)[]) => string;
+type Selector = (strings: TemplateStringsArray, ... values: (ResolvedValue | number | boolean | ComponentType)[]) => string;
 
 /**
  * Validated selectors


### PR DESCRIPTION
Hi again, this is a follow up to #99, I have not thoroughly tested the solution proposed solution and after introducing it to a project discovered a few edge cases, to be more specific 

- missing `number | boolean` for `Selector` type

```typescript
import {select} from 'reselector'

const selectThing = (nth, toggled) => select`*:nth(${nth}) [data-toggled="${toggled}"]`
```

- JSX namespace requires `@types/react`, this one is tricky since typescript's LSP by default pulls types for d.ts files into global cache like `/Users/anon/.cache/typescript/4.2/node_modules/@types/react/index.d.ts`, therefore I think it would be safer to remove JSX usage