### PR TITLE
Fix [DEP0128] DeprecationWarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Use React Components in css selectors",
   "repository": {
     "type": "git",
-    "url": "git@github.com:lttb/reselector.git"
+    "url": "git@github.com:yandex/reselector.git"
   },
   "author": "",
   "license": "MPL-2.0",
-  "main": "src/index.js",
+  "main": "index.js",
   "scripts": {
     "clean": "rimraf lib",
     "prebuild": "npm run clean",


### PR DESCRIPTION
fix error in console
```
(node:85201) [DEP0128] DeprecationWarning: Invalid 'main' field in '<project>/node_modules/reselector/package.json' of 'src/index.js'. Please either fix that or report it to the module author
```